### PR TITLE
Fix CVE-2025-5889: brace-expansion: juliangruber brace-expansion index.js expand redos

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -4119,9 +4119,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,6 +12,9 @@
     "vuepress-plugin-clean-urls": "^1.1.1",
     "vuepress-plugin-redirect": "^1.2.5"
   },
+  "overrides": {
+    "brace-expansion": "1.1.12"
+  },
   "directories": {
     "doc": "docs"
   },


### PR DESCRIPTION
## Overview
This pull request fixes **CVE-2025-5889**, a Regular Expression Denial of Service (ReDoS) vulnerability in the brace-expansion package.

## Vulnerability Details
- **CVE ID**: CVE-2025-5889
- **Severity**: LOW (CVSS Score: 3.1)
- **Package**: brace-expansion
- **Vulnerable Version**: 1.1.11
- **Fixed Version**: 1.1.12
- **Issue**: Inefficient regular expression complexity in the expand function
- **Attack Vector**: Network (AV:N)
- **Attack Complexity**: High (AC:H)

## Changes Made

### 1. Added npm overrides to package.json
Added an `overrides` section to `docs/package.json` to explicitly enforce brace-expansion version 1.1.12:
```json
"overrides": {
  "brace-expansion": "1.1.12"
}
```

This is an **improvement over the previous approach** as it:
- Ensures the fixed version is enforced across all transitive dependencies
- Prevents future npm installs from reverting to vulnerable versions
- Makes the security fix explicit and maintainable
- Works with npm 8.3+ (which we're using: npm 10.9.4)

### 2. Updated package-lock.json
- Updated `docs/package-lock.json` to upgrade brace-expansion from version 1.1.11 to 1.1.12
- Regenerated lock file with `npm install` to apply the override

## Testing & Verification

✅ **Dependency Installation**: Successfully ran `npm install` with updated package-lock.json
✅ **Version Enforcement**: Verified brace-expansion@1.1.12 is installed in node_modules
✅ **Package Integrity**: Confirmed integrity hashes in package-lock.json
✅ **Override Application**: Verified the override is properly applied to all dependency references

## Impact Assessment
- **Breaking Changes**: None
- **Functionality Impact**: None - This is a patch version update
- **Dependencies Affected**: Only brace-expansion updated
- **Backwards Compatibility**: Maintained

## Files Modified
- `docs/package.json` - Added overrides section
- `docs/package-lock.json` - Updated brace-expansion version

## Why This Approach is Better

The previous attempt only updated package-lock.json. Our improved fix:
1. **Explicitly declares the security requirement** in package.json
2. **Persists across npm installs** - Even if someone runs `npm install` fresh, the override ensures version 1.1.12 is used
3. **Prevents regression** - The override prevents any dependency from pulling in vulnerable versions
4. **Documents the fix** - The override in package.json makes it clear this is intentional

## References
- **CVE**: CVE-2025-5889
- **Red Hat Advisory**: https://access.redhat.com/security/cve/CVE-2025-5889
- **Exploit Information**: https://gist.github.com/mmmsssttt404/37a40ce7d6e5ca604858fe30814d9466
- **Patch Commit**: a5b98a4f30d7813266b221435e1eaaf25a1b0ac5
- **CWE**: CWE-400 (Uncontrolled Resource Consumption)

## Recommendations
After merging this PR:
1. Run `npm install` in the `docs/` directory to update local dependencies
2. The override in package.json will ensure the fix persists
3. Consider implementing automated dependency scanning in CI/CD pipeline
4. Review other reported npm vulnerabilities for remediation

## Note
This vulnerability has low severity and high attack complexity, but fixing it improves the overall security posture of the project. The use of npm overrides ensures this fix is maintainable and persistent.